### PR TITLE
[fix] redraw RoughUIView when the options are changed

### DIFF
--- a/Sources/RoughSwift/Engine/Options.swift
+++ b/Sources/RoughSwift/Engine/Options.swift
@@ -72,3 +72,27 @@ public extension Options {
         fill <-? (dictionary["fill"] as? String).map(UIColor.init(hex:))
     }
 }
+
+extension Options: Hashable {
+    public static func == (lhs: Options, rhs: Options) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(maxRandomnessOffset)
+        hasher.combine(roughness)
+        hasher.combine(bowing)
+        hasher.combine(fill)
+        hasher.combine(stroke)
+        hasher.combine(strokeWidth)
+        hasher.combine(curveTightness)
+        hasher.combine(curveStepCount)
+        hasher.combine(fillStyle)
+        hasher.combine(fillWeight)
+        hasher.combine(hachureAngle)
+        hasher.combine(hachureGap)
+        hasher.combine(dashOffset)
+        hasher.combine(dashGap)
+        hasher.combine(zigzagOffset)
+    }
+}

--- a/Sources/RoughSwift/RoughUIView.swift
+++ b/Sources/RoughSwift/RoughUIView.swift
@@ -10,7 +10,19 @@ import UIKit
 
 final class RoughUIView: UIView {
     var drawbles: [Drawable]?
-    var options: Options?
+
+    var options: Options? {
+        didSet {
+            guard options != oldValue else {
+                return
+            }
+            guard let drawbles, let options else {
+                return
+            }
+            update(drawables: drawbles, options: options)
+        }
+    }
+
     var previousBounds: CGRect = .zero
 
     override func layoutSubviews() {


### PR DESCRIPTION
Hi, I find an issue when using RoughSwift, but I‘m not sure if it‘s a bug.
Then I submitted the PR to fix it. Please review the code to see if it is reasonable.

The issue is when I use the `@State`  to update some values in the options of RoughView, but the RoughView does not refresh. So I added the `update` function to `didSet` in the options. Because I have to figure out if the old options are equal to the new options. So I made the `Options` to confirm the `Hashable` protocol.

Here is the video after the code is updated:

https://user-images.githubusercontent.com/20198012/218316569-d02341c4-a174-44e1-baab-bc8a8c67801a.mp4

