### PR TITLE
Make Line initializer accessible

### DIFF
--- a/Sources/RoughSwift/Engine/Drawable.swift
+++ b/Sources/RoughSwift/Engine/Drawable.swift
@@ -23,6 +23,14 @@ public struct Line: Drawable {
 
     let from: Point
     let to: Point
+    
+    public init(
+        from: Point,
+        to: Point
+    ) {
+        self.from = from
+        self.to = to
+    }
 }
 
 public struct Rectangle: Drawable {


### PR DESCRIPTION
'Line' initializer is inaccessible due to 'internal' protection level. This PR fixes that issue.